### PR TITLE
schema.org dos palestrantes na parte visível do html

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,60 +55,60 @@
     <div role="main" class="main">
       <section id="speakers" class="container">
         <ul>
-          <li itemprop="performer" itemscope itemtype="http://schema.org/Person">
+          <li>
             <article rel="popover" title="HTML5 Sensitivo – Seu browser no plano astral" data-placement="bottom" data-content="O navegador está cada vez mais sensível ao seus arredores.<br/>
 Explorando todos os novos sensores disponíveis no HTML5 – acelerômetro, geolocalização, câmera e microfone –, vamos acessar todas as API's do aqui e do além.<hr/><div class='bio'><strong>Caio Gondim</strong><br/>Web developer, viajante, surfista e pára-quedista. Co-fundador e autor do @loopinfinito. Curte uma heineken ao fim dos eventos. Vai?.<br/><br/><strong>Almir Filho</strong><br/>Full Stack Developer. Co-fundador e autor do Loop Infinito. Graduado e Mestrando em Ciência da Computação pela UFMA, se amarra em produtividade e em ter um estilo de vida like a rocker.</div>">
               <a href="#loopinfinito-keynote" class="avatar-wrapper"><img src="img/speakers/loopinfinito/caio.png" alt="Atavar Caio Gondim - Loop Infinito " width="121" height="121"></a>
-              <h3 itemprop="name">Caio Gondim</h3>
+              <h3>Caio Gondim</h3>
               <strong>Loop Infinito</strong>
             </article>
           </li>
-          <li itemprop="performer" itemscope itemtype="http://schema.org/Person">
+          <li>
             <article rel="popover" title="HTML5 Sensitivo – Seu browser no plano astral" data-placement="bottom" data-content="O navegador está cada vez mais sensível ao seus arredores.<br/>
 Explorando todos os novos sensores disponíveis no HTML5 – acelerômetro, geolocalização, câmera e microfone –, vamos acessar todas as API's do aqui e do além.<hr/><div class='bio'><strong>Caio Gondim</strong><br/>Web developer, viajante, surfista e pára-quedista. Co-fundador e autor do @loopinfinito. Curte uma heineken ao fim dos eventos. Vai?.<br/><br/><strong>Almir Filho</strong><br/>Full Stack Developer. Co-fundador e autor do Loop Infinito. Graduado e Mestrando em Ciência da Computação pela UFMA, se amarra em produtividade e em ter um estilo de vida like a rocker.</div>">
               <a href="#loopinfinito-keynote" class="avatar-wrapper"><img src="img/speakers/loopinfinito/almir.png" alt="Atavar Almir Filho - Loop Infinito " width="121" height="121"></a>
-              <h3 itemprop="name">Almir Filho</h3>
+              <h3>Almir Filho</h3>
               <strong>Loop Infinito</strong>
             </article>
           </li>
-          <li itemprop="performer" itemscope itemtype="http://schema.org/Person">
+          <li>
             <article rel="popover" title="Uma sugestão baseada em simplicidade para o padrão Singleton de projeto para JS" data-placement="bottom" data-content="Baseando-se nos conceitos de simplicidade, o SSP torna fácil a aplicação do JS em um projeto até por aqueles que estão começando. Essa técnica, sugerida por diversos autores, recebeu uma pitada de praticidade e pode tornar seu código mais manutenível e de fácil adoção por novos integrantes na equipe..<hr/><div class='bio'><strong>Dennis Calazans</strong><br/>Dennis é tecnólogo em sistemas para a internet (FMR) e é mestre em Design (UFPE). Atua como professor nas faculdades Marista Recife (FMR) e UNIBRATEC. Também ministra em cursos de pós-graduação nas áreas de Engenharia Front-End (FMR), Web Apps (UNIBRATEC) e Serviços e Soluções Inteligentes (CESAR.EDU)</div>">
               <a href="#dennis-keynote" class="avatar-wrapper"><img src="img/speakers/dennis.png" alt="Atavar do Dennis" width="121" height="121"></a>
-              <h3 itemprop="name">Dennis Calazans</h3>
+              <h3>Dennis Calazans</h3>
               <strong>Unibratec/Marista</strong>
             </article>
           </li>
-          <li itemprop="performer" itemscope itemtype="http://schema.org/Person">
+          <li>
             <article rel="popover" title="Performance Front-end com resultados" data-placement="bottom" data-content="Por uma web mais rápida, mostrarei um pouco como é importante a performance em uma aplicação web e como isso pode retornar grande valor para você(profissional) e empresa. Grandes dicas bobas mas que bem usadas são de grande valor.<hr/><div class='bio'><strong>Giovanni Keppelen</strong><br/>Curador do Front in BH e moderador do Rio.js. Estudante de Produção Multimídia Production na UNI-BH. Front-end Engineer e Tech Leader no <a href='http://peixeurbano.com.br'>Peixe Urbano</a>, sempre focando em performance.</div>">
               <a href="#giovanni-keynote" class="avatar-wrapper"><img src="img/speakers/giovanni.png" alt="Atavar do Giovanni Keppelen" width="121" height="121"></a>
-              <h3 itemprop="name">Giovanni Keppelen</h3>
+              <h3>Giovanni Keppelen</h3>
               <strong>Peixe Urbano</strong>
             </article>
           </li>
-          <li itemprop="performer" itemscope itemtype="http://schema.org/Person">
+          <li>
             <article rel="popover" title="Schema.org: HTML semântico" data-placement="bottom" data-content="Iniciativa de empresas como Google, Microsoft e Yahoo, o schema.org tem um conjunto de vocabulários para embutir semântica no HTML e traz várias vantagens como melhoria de SEO, rich snippets, entre outros. Aprenda como usar o formato e explorar essas vantagens.<hr/><div class='bio'><strong>Ícaro Medeiros</strong><br/>Desenvolvedor do time de Semântica da globo.com. Doutorando em Informática na PUC-RIO, Mestre pela UFPE e Bacharel pela UFAL.</div>">
               <a href="#icaro-keynote" class="avatar-wrapper"><img src="img/speakers/icaro.png" alt="Atavar do Ícaro Medeiros" width="121" height="121"></a>
-              <h3 itemprop="name">Ícaro Medeiros</h3>
+              <h3>Ícaro Medeiros</h3>
               <strong>Globo.com</strong>
             </article>
           </li>
-          <li itemprop="performer" itemscope itemtype="http://schema.org/Person">
+          <li>
             <article rel="popover" title="Quero ser um ninja em xHTML, HTML5 e CSS3" data-placement="bottom" data-content="Já sabe codificar? Quer chegar a um nível destacado no mercado? Práticas avançadas de documentação, velocidade de codificação, modularização. Tudo isso recheado a muitas dicas de corte de layouts e inovações em CSS3!.<hr/><div class='bio'><strong>Bernard de Luna</strong><br/>UI Designer e Front-end Developer em São Paulo. Ele já trabalhou na Petrobras liderando um time de Front-end para construir aplicações incríveis, ele também é especialista em projetos sexy para web e criador do Framework http://formee.org . Atualmente ele trabalha como UX e Creative Director na Melt DSP.</div>">
               <a href="#bernard-keynote" class="avatar-wrapper"><img src="img/speakers/bernard.png" alt="Atavar do Bernard de Luna" width="121" height="121"></a>
-              <h3 itemprop="name">Bernard de Luna</h3>
+              <h3>Bernard de Luna</h3>
               <strong>Melt DSP</strong>
             </article>
           </li>
-          <li itemprop="performer" itemscope itemtype="http://schema.org/Person">
+          <li>
             <article class="undefined">
               <a href="#" class="avatar-wrapper"><img src="img/speakers/undefined.png" alt="Awesome Speaker Soon" width="121" height="121"></a>
-              <h3 itemprop="name">Em breve</h3>
+              <h3>Em breve</h3>
             </article>
           </li>
-          <li itemprop="performer" itemscope itemtype="http://schema.org/Person">
+          <li>
             <article class="undefined">
               <a href="#" class="avatar-wrapper"><img src="img/speakers/undefined.png" alt="Awesome Speaker Soon" width="121" height="121"></a>
-              <h3 itemprop="name">Em breve</h3>
+              <h3>Em breve</h3>
             </article>
           </li>
         </ul>
@@ -132,7 +132,7 @@ Explorando todos os novos sensores disponíveis no HTML5 – acelerômetro, geol
       </section>
 
       <section id="highlight-text">
-      <p>Seguindo o sucesso de outros eventos, o <item itemsprop="name">Front in Maceió</item> <br /> será o <strong>primeiro evento</strong> focado em desenvolvimento frontend<br/> no nordeste do Brasil.</p>
+      <p>Seguindo o sucesso de outros eventos, o <item itemprop="name">Front in Maceió</item> <br /> será o <strong>primeiro evento</strong> focado em desenvolvimento frontend<br/> no nordeste do Brasil.</p>
       </section>
     </div>
 
@@ -143,8 +143,8 @@ Explorando todos os novos sensores disponíveis no HTML5 – acelerômetro, geol
     <section class="container talks">
       <h4 class="title">Palestras</h4>
       <ul class="talks-list">
-          <li class="talks-item" id="loopinfinito-keynote">
-            <a href="#loopinfinito-keynote" class="avatar-wrapper"><img src="img/speakers/loopinfinito/l8p.png" alt="" width="121" height="121" class="talk-picture picture"></a>
+          <li class="talks-item" id="loopinfinito-keynote" itemprop="performer" itemscope itemtype="http://schema.org/Person">
+            <a href="#loopinfinito-keynote" class="avatar-wrapper"><img src="img/speakers/loopinfinito/l8p.png" itemprop="image" alt="" width="121" height="121" class="talk-picture picture"></a>
             <article class="talk-description">
             <h5 class="talk-title">HTML5 Sensitivo – Seu browser no plano astral</h5>
             <h6 class="talk-speaker">Almir Filho &amp; Caio Gondim (Loop Infinito)</h6>
@@ -153,8 +153,8 @@ Explorando todos os novos sensores disponíveis no HTML5 – acelerômetro, geol
 Explorando todos os novos sensores disponíveis no HTML5 – acelerômetro, geolocalização, câmera e microfone – vamos acessar todas as API's do aqui e do além.</p>
             </article>
           </li>
-          <li class="talks-item right" id="dennis-keynote">
-            <a href="#dennis-keynote" class="avatar-wrapper"><img src="img/speakers/dennis.png" alt="" width="121" height="121" class="talk-picture picture"></a>
+          <li class="talks-item right" id="dennis-keynote" itemprop="performer" itemscope itemtype="http://schema.org/Person">
+            <a href="#dennis-keynote" class="avatar-wrapper"><img src="img/speakers/dennis.png" itemprop="image" alt="" width="121" height="121" class="talk-picture picture"></a>
             <article class="talk-description">
               <h5 class="talk-title">Uma sugestão baseada em simplicidade para o padrão Singleton para JS</h5>
               <h6 class="talk-speaker">Dennis Calazans (Unibratec/Marista)</h6>
@@ -163,8 +163,8 @@ Explorando todos os novos sensores disponíveis no HTML5 – acelerômetro, geol
               </p>
             </article>
           </li>
-          <li class="talks-item" id="bernard-keynote">
-            <a href="#bernard-keynote" class="avatar-wrapper"><img src="img/speakers/bernard.png" alt="" width="121" height="121" class="talk-picture picture"></a>
+          <li class="talks-item" id="bernard-keynote" itemprop="performer" itemscope itemtype="http://schema.org/Person">
+            <a href="#bernard-keynote" class="avatar-wrapper"><img src="img/speakers/bernard.png" itemprop="image" alt="" width="121" height="121" class="talk-picture picture"></a>
             <article class="talk-description">
               <h5 class="talk-title">Quero ser um ninja em xHTML, HTML5 e CSS3</h5>
               <h6 class="talk-speaker">Bernard de Luna (Melt DSP)</h6>
@@ -173,8 +173,8 @@ Explorando todos os novos sensores disponíveis no HTML5 – acelerômetro, geol
               </p>
             </article>
           </li>
-          <li class="talks-item right" id="icaro-keynote">
-            <a href="#icaro-keynote" class="avatar-wrapper"><img src="img/speakers/icaro.png" alt="" width="121" height="121" class="talk-picture picture"></a>
+          <li class="talks-item right" id="icaro-keynote" itemprop="performer" itemscope itemtype="http://schema.org/Person">
+            <a href="#icaro-keynote" class="avatar-wrapper"><img src="img/speakers/icaro.png" itemprop="image" alt="" width="121" height="121" class="talk-picture picture"></a>
             <article class="talk-description">
               <h5 class="talk-title">Schema.org: HTML semântico</h5>
               <h6 class="talk-speaker">Ícaro Medeiros (Globo.com)</h6>
@@ -183,8 +183,8 @@ Explorando todos os novos sensores disponíveis no HTML5 – acelerômetro, geol
               </p>
             </article>
           </li>
-          <li class="talks-item" id="giovanni-keynote">
-            <a href="#giovanni-keynote" class="avatar-wrapper"><img src="img/speakers/giovanni.png" alt="" width="121" height="121" class="talk-picture picture"></a>
+          <li class="talks-item" id="giovanni-keynote" itemprop="performer" itemscope itemtype="http://schema.org/Person">
+            <a href="#giovanni-keynote" class="avatar-wrapper"><img src="img/speakers/giovanni.png" itemprop="image" alt="" width="121" height="121" class="talk-picture picture"></a>
             <article class="talk-description">
               <h5 class="talk-title">Performance Front-end com resultados</h5>
               <h6 class="talk-speaker">Giovanni Keppelen (Peixe Urbano)</h6>
@@ -199,16 +199,16 @@ Explorando todos os novos sensores disponíveis no HTML5 – acelerômetro, geol
     <section class="container talks lightning-talks">
       <h4 class="title">Lightning talks</h4>
       <ul class="talks-list">
-          <li class="talks-item right" id="luiz-lightning-talk">
-            <a href="#luiz-lightning-talk" class="avatar-wrapper"><img src="img/speakers/lightning-talks/luiz.jpg" alt="avatar do luiz tiago" width="121" height="121" class="talk-picture picture"></a>
+          <li class="talks-item right" id="luiz-lightning-talk" itemprop="performer" itemscope itemtype="http://schema.org/Person">
+            <a href="#luiz-lightning-talk" class="avatar-wrapper"><img src="img/speakers/lightning-talks/luiz.jpg" itemprop="image" alt="avatar do luiz tiago" width="121" height="121" class="talk-picture picture"></a>
             <article class="talk-description">
             <h5 class="talk-title">Zepto.JS - Fazendo "mais com menos"</h5>
             <h6 class="talk-speaker">Luiz Tiago Oliveira (MGR Tecnologia)</h6>
             <p class="talk-text">A árdua tarefa de escolher qual biblioteca utilizar nos projetos fica cada vez mais difícil. Zepto é uma biblioteca minimalista desenvolvida para browsers modernos, tão simples de ser usada quanto o jQuery. E bem mais leve!</p>
             </article>
           </li>
-          <li class="talks-item" id="ramon-lightning-talk">
-            <a href="#ramon-lightning-talk" class="avatar-wrapper"><img src="img/speakers/lightning-talks/ramon.jpg" alt="" width="121" height="121" class="talk-picture picture"></a>
+          <li class="talks-item" id="ramon-lightning-talk" itemprop="performer" itemscope itemtype="http://schema.org/Person">
+            <a href="#ramon-lightning-talk" class="avatar-wrapper"><img src="img/speakers/lightning-talks/ramon.jpg" itemprop="image" alt="" width="121" height="121" class="talk-picture picture"></a>
             <article class="talk-description">
               <h5 class="talk-title">Pré-processadores CSS: porque são bons e onde devemos tomar cuidado</h5>
               <h6 class="talk-speaker">Ramon Victor (TangerinaLab)</h6>


### PR DESCRIPTION
Troca do schema.org de performer (palestrante) para a parte visível do HTML, mais ao final da página. Também coloquei no schema as imagens dos avatares dos palestrantes.
