### PR TITLE
Fixes do schema.org para validação html #8

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
   <![endif]-->
 
   <meta name="viewport" content="width=device-width">
-  <meta itemprop="description" name="description" content="O Front in Maceió 2012 tem foco em desenvolvimento Front-end e o evento acontecerá em Maceió no dia 27 de Outubro no auditório principal do CESMAC">
+  <meta name="description" content="O Front in Maceió 2012 tem foco em desenvolvimento Front-end e o evento acontecerá em Maceió no dia 27 de Outubro no auditório principal do CESMAC">
   <meta property="og:title" content="Front in Maceió 2012">
   <meta property="og:type" content="website">
   <meta property="og:description" content="O Front in Maceió 2012 tem foco em desenvolvimento Front-end e o evento acontecerá em Maceió no dia 27 de Outubro no auditório principal do CESMAC">
@@ -37,7 +37,7 @@
     <header class="container">
       <hgroup>
         <h1><a href="/"><img src="img/logo.png" alt="Front in Maceió" class="logo" width="193" height="83"></a></h1>
-        <h2><strong><time itemprop="startDate" itemprop="endDate" datetime="2012-10-27">27 de out</time></strong> CESMAC - Maceió</h2>
+        <h2><strong><time itemprop="startDate" datetime="2012-10-27">27 de out</time></strong> CESMAC - Maceió</h2>
       </hgroup>
       <div class="social-media">
         <a href="http://fb.com/frontinmaceio" rel="external" class="fb">Front in Maceió on Facebook</a>
@@ -140,7 +140,7 @@ Explorando todos os novos sensores disponíveis no HTML5 – acelerômetro, geol
       </section>
 
       <section id="highlight-text">
-      <p>Seguindo o sucesso de outros eventos, o <item itemprop="name">Front in Maceió</item> <br /> será o <strong>primeiro evento</strong> focado em desenvolvimento frontend<br/> no nordeste do Brasil.</p>
+      <p>Seguindo o sucesso de outros eventos, o <span itemprop="name">Front in Maceió</span> <br /> será <span itemprop="description">o <strong>primeiro evento</strong> focado em desenvolvimento frontend<br/> no nordeste do Brasil.</span></p>
       </section>
     </div>
 


### PR DESCRIPTION
Comentários (issue #8):

1 - Eu sabia que não era RECOMENDADO colocar itemprop em lugares invisíveis ao usuário mas não que ia invalidar o HTML colocar schema.org no meta description. Tinha colocado lá porque o texto é melhor que aquele do "destaque com fundo roxo" da página. Mas troquei pra ele agora, paciência.

2 - Esse endDate tá errado mesmo, e nem precisa porque como é só um dia o startDate é suficiente. Daria pra colocar o atributo duration, mas é over. PS: Não fui eu.

3 - coloquei um item no meio do texto BEM ERRADO mesmo, era um span :)
