### PR TITLE
Fix display on iPhones and iPads on some areas

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,6 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <![endif]-->
 
-<!--   <meta name="viewport" content="width=device-width;"> -->
   <meta name="description" content="O Front in Maceió 2012 tem foco em desenvolvimento Front-end e o evento acontecerá em Maceió no dia 27 de Outubro no auditório principal do CESMAC">
   <meta property="og:title" content="Front in Maceió 2012">
   <meta property="og:type" content="website">


### PR DESCRIPTION
Galera, gostaria de abrir uma discussao sobre isso:

o site tava com umas áreas bugadas no iPad e iPhone (nao testei em androids) devido a uma tag que se tem usado muito pra evitar problemas de leitura em dispositivos móveis

&lt;meta name="viewport" content="width=device-width;"&gt;

Pelo que vi, ao usar essa tag, as áreas que são 100% da tela se perdem na renderização, fazendo com que o browser ache que tem uma dimensão (ex, 320 no iphone e 768 no iPad), onde deveria retornar o valor do site total (980, no caso). Alguem com mais experiencia poderia explicar melhor isso?

Li em: http://tech.bluesmoon.info/2011/01/device-width-and-how-not-to-hate-your.html
<b>width=device-width</b>
Most sites that I've seen advise you to set the content attribute to width=device-width. This tells the browser to assume that the page is as wide as the device. Unfortunately, this is only true when your device is in the portrait orientation. When you rotate to landscape, the device-width remains the same (eg: 320px), which means that even if your page were designed to work well in a 480px landscape design, it would still be rendered as if it were 320px.
